### PR TITLE
fix regexp in const passwordPatterns

### DIFF
--- a/src/shared/utils/constants.ts
+++ b/src/shared/utils/constants.ts
@@ -1,6 +1,7 @@
 export const authRoutes = [
   "/auth/login",
   "/auth/signup",
+  "/auth/sign-up",
   "/auth/magic",
   "/auth/reset-password",
   "/auth/logout",
@@ -18,6 +19,6 @@ export const publicRoutes = [
 
 export const passwordPatterns = {
   middleStrength: new RegExp(
-    "^(?=.*[A-Z])(?=.*[!@#$&*])(?=.*[0-9])(?=.*[a-z].*[a-z].*[a-z]).{8}$"
+    "^(?=.*[A-Z])(?=.*[!@#$&*])(?=.*[0-9])(?=.*[a-z].*[a-z].*[a-z]).{8,}$"
   ),
 };

--- a/src/v15/pages/validators/auth-validators.ts
+++ b/src/v15/pages/validators/auth-validators.ts
@@ -15,6 +15,7 @@ export const SignUpFormSchema = (isMagicLogin: boolean) =>
     ...(isMagicLogin
       ? {}
       : {
+        // VITOR > APÓS CORRIGIR PROBLEMA, REPLICAR NO V14
           password: z.string().regex(passwordPatterns.middleStrength, {
             message:
               'Password must have at least 8 characters, one uppercase letter, one special character and one digit.',

--- a/src/v15/pages/validators/auth-validators.ts
+++ b/src/v15/pages/validators/auth-validators.ts
@@ -15,7 +15,6 @@ export const SignUpFormSchema = (isMagicLogin: boolean) =>
     ...(isMagicLogin
       ? {}
       : {
-        // VITOR > APÓS CORRIGIR PROBLEMA, REPLICAR NO V14
           password: z.string().regex(passwordPatterns.middleStrength, {
             message:
               'Password must have at least 8 characters, one uppercase letter, one special character and one digit.',


### PR DESCRIPTION
- The user was unable to create a password, even while following the "strong password" requirements;

- An error was found in the RegExp in constants.ts, line 20, const passwordPatterns;

- The error was fixed, and strong password creation now follows the requirements and prevents the creation of passwords outside the parameters.